### PR TITLE
fix: fixed .get,post middleware chaining bugs for each methods

### DIFF
--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -399,7 +399,7 @@ function parseCookie(cookieHeader: string): Record<string, string> {
   );
 }
 
-async function parseBody(req: Request, body_size_limit: number | undefined): Promise<ParseBodyResult> {
+async function parseBody(req: Request): Promise<ParseBodyResult> {
   const contentType: string = req.headers.get("Content-Type") || "";
   if (!contentType) return {};
 
@@ -411,7 +411,7 @@ async function parseBody(req: Request, body_size_limit: number | undefined): Pro
     try {
       return await req.json();
     } catch (error) {
-      throw new Error("Invalid JSON in request body");
+      throw new Error("Invalid request body format");
     }
   }
 

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -399,17 +399,20 @@ function parseCookie(cookieHeader: string): Record<string, string> {
   );
 }
 
-async function parseBody(req: Request): Promise<ParseBodyResult> {
+async function parseBody(req: Request, body_size_limit: number | undefined): Promise<ParseBodyResult> {
   const contentType: string = req.headers.get("Content-Type") || "";
   if (!contentType) return {};
 
-  const contentLength = req.headers.get("Content-Length");
-  if (contentLength === "0" || !req.body) {
+  if (!req.body) {
     return {};
   }
 
   if (contentType.startsWith("application/json")) {
-    return await req.json();
+    try {
+      return await req.json();
+    } catch (error) {
+      throw new Error("Invalid JSON in request body");
+    }
   }
 
   if (contentType.startsWith("application/x-www-form-urlencoded")) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,8 @@ import { Router, RouterFactory } from "./router/interface.js";
 import { ALL_METHOD, EMPTY_OBJ, supportedMethods } from "./constant.js";
 import { isPromise } from "./utils/promise.js";
 
+type RouteHooks = Partial<Record<HookType, Array<Function>>>;
+
 export default class Diesel {
   private static instance: Diesel;
   routes: Record<string, Function>;
@@ -68,7 +70,7 @@ export default class Diesel {
   hasFilterEnabled: boolean;
   private serverInstance: Server | null;
   staticFiles: any;
-  user_jwt_secret: string;
+  user_jwt_secret: string | undefined;
   baseApiUrl: string;
   private enableFileRouter: boolean;
   idleTimeOut: number;
@@ -96,6 +98,8 @@ export default class Diesel {
   options!: RouteHandler;
   propfind!: RouteHandler;
   all!: RouteHandler;
+
+  route_hooks: RouteHooks = {};
 
   constructor(options: DieselOptions = {}) {
     supportedMethods.forEach((method) => {
@@ -145,10 +149,7 @@ export default class Diesel {
     this.idleTimeOut = idleTimeOut ?? 10;
     this.enableFileRouter = enableFileRouting ?? false;
     this.baseApiUrl = baseApiUrl || "";
-    this.user_jwt_secret =
-      jwtSecret ||
-      process.env.DIESEL_JWT_SECRET ||
-      "default_diesel_secret_for_jwt";
+    this.user_jwt_secret = jwtSecret || process.env.DIESEL_JWT_SECRET;
     this.tempRoutes = new Map<string, TempRouteEntry>();
     this.corsConfig = null;
     this.hasOnReqHook = false;
@@ -263,19 +264,30 @@ export default class Diesel {
       },
 
       authenticateJwt: (jwt: any) => {
+        if (!this.user_jwt_secret)
+          throw new Error(
+            "You must provide jwtSecret in Diesel Options to use authenticateJwt",
+          );
         const wrapper = async (ctx: Context) => {
           const pathname = ctx.path!;
           for (const pub of this.filters) {
             if (pathname.startsWith(pub)) return;
           }
 
-          const res = authenticateJwtMiddleware(jwt, this.user_jwt_secret)(ctx);
+          const res = authenticateJwtMiddleware(
+            jwt,
+            this.user_jwt_secret!,
+          )(ctx);
           if (res) return res;
         };
         this.router.addMiddleware("/", wrapper);
       },
 
       authenticateJwtDB: (jwt: any, User: any) => {
+        if (!this.user_jwt_secret)
+          throw new Error(
+            "You must provide jwtSecret in Diesel Options to use authenticateJwt",
+          );
         const wrapper = async (ctx: Context) => {
           const pathname = ctx.path!;
           for (const pub of this.filters) {
@@ -285,7 +297,7 @@ export default class Diesel {
           const res = authenticateJwtDbMiddleware(
             jwt,
             User,
-            this.user_jwt_secret,
+            this.user_jwt_secret!,
           )(ctx);
           if (res) return res;
         };
@@ -549,8 +561,10 @@ export default class Diesel {
 
       let finalResult;
       if (matchedRouteHandler.handler) {
-        const result = matchedRouteHandler.handler(ctx);
-        finalResult = isPromise(result) ? await result : result;
+        for (let i = 0; i < matchedRouteHandler?.handler?.length; i++) {
+          const result = matchedRouteHandler.handler[i](ctx);
+          finalResult = isPromise(result) ? await result : result;
+        }
       }
 
       // onSend
@@ -572,7 +586,7 @@ export default class Diesel {
 
   // HandleError
   private async handleError(err: unknown, path: string, req: Request) {
-    const isDev = process.env.NODE_ENV === "developement";
+    const isDev = process.env.NODE_ENV === "development";
 
     const format = this.errorFormat;
 
@@ -687,18 +701,8 @@ export default class Diesel {
     for (const [path, args] of tempRoutes.entries()) {
       const cleanedPath = path.replace(/::\w+$/, "");
       const fullpath = `${basePath}${cleanedPath}`;
-
-      // Add all middleware functions for the route, preserving user-defined order.
-      const middlewareHandlers = args.handlers.slice(0, -1) as middlewareFunc[];
-      this.router.addMiddleware(fullpath, middlewareHandlers);
-
-      const handler = args.handlers[args.handlers.length - 1];
       const method = args.method;
-      try {
-        this.router.add(method, fullpath, handler as handlerFunction);
-      } catch (error) {
-        console.error(`Error inserting ${fullpath}:`, error);
-      }
+        this.router.add(method, fullpath, args.handlers as unknown as Function[]);
     }
 
     // Middleware assigning
@@ -757,18 +761,8 @@ export default class Diesel {
       );
 
     this.tempRoutes?.set(path + "::" + method, { method, handlers });
-    const middlewareHandlers = handlers.slice(0, -1) as middlewareFunc[];
-    const handler = handlers[handlers.length - 1];
-
-    if (middlewareHandlers.length > 0)
-      this.addMiddlewareInRouter(path, middlewareHandlers);
-
-    try {
-      method = method === "ANY" ? ALL_METHOD : method;
-      this.router.add(method, path, handler);
-    } catch (error) {
-      console.error(`Error inserting ${path}:`, error);
-    }
+    method = method === "ANY" ? ALL_METHOD : method;
+    this.router.add(method, path, handlers as unknown as Function[]);
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -700,7 +700,7 @@ export default class Diesel {
       const cleanedPath = path.replace(/::\w+$/, "");
       const fullpath = `${basePath}${cleanedPath}`;
       const method = args.method;
-        this.router.add(method, fullpath, args.handlers as unknown as Function[]);
+      this.router.add(method, fullpath, args.handlers as unknown as Function[]);
     }
 
     // Middleware assigning

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,6 @@ import { Router, RouterFactory } from "./router/interface.js";
 import { ALL_METHOD, EMPTY_OBJ, supportedMethods } from "./constant.js";
 import { isPromise } from "./utils/promise.js";
 
-type RouteHooks = Partial<Record<HookType, Array<Function>>>;
 
 export default class Diesel {
   private static instance: Diesel;
@@ -98,8 +97,6 @@ export default class Diesel {
   options!: RouteHandler;
   propfind!: RouteHandler;
   all!: RouteHandler;
-
-  route_hooks: RouteHooks = {};
 
   constructor(options: DieselOptions = {}) {
     supportedMethods.forEach((method) => {
@@ -561,9 +558,10 @@ export default class Diesel {
 
       let finalResult;
       if (matchedRouteHandler.handler) {
-        for (let i = 0; i < matchedRouteHandler?.handler?.length; i++) {
-          const result = matchedRouteHandler.handler[i](ctx);
+        for (const fn of matchedRouteHandler.handler) {
+          const result = fn(ctx);
           finalResult = isPromise(result) ? await result : result;
+          if (finalResult) break;
         }
       }
 

--- a/src/router/interface.ts
+++ b/src/router/interface.ts
@@ -2,7 +2,7 @@ import { TrieRouter } from "./trie.js";
 
 
 export interface Router {
-    add(method: string, path: string, handler: Function): void
+    add(method: string, path: string, handler: Function | Function[]): void
     find(method: string, path: string): Find
     addMiddleware(path: string, handlers: Function | Function[]): void
 }
@@ -10,7 +10,7 @@ export interface Router {
 export interface Find {
     params: Record<string, string> | undefined;
     middlewares: Function[] | undefined;
-    handler: Function | undefined;
+    handler: Array<Function> | undefined;
 }
 
 export class RouterFactory {

--- a/src/router/trie.ts
+++ b/src/router/trie.ts
@@ -59,8 +59,8 @@ export class TrieRouter {
     let node = this.root;
 
     if (path === "/") {
-      node.handlers[method] ??= [];
-      node.handlers[method].push(...handlers);
+      if (node.handlers[method]) return;
+      node.handlers[method] = handlers;
       node.params = EMPTY_OBJ;
       return;
     }
@@ -86,8 +86,8 @@ export class TrieRouter {
       }
     }
     node.params = routeparams;
-    node.handlers[method] ??= [];
-    node.handlers[method].push(...handlers);
+    if (node.handlers[method]) return;
+    node.handlers[method] = handlers;
   }
 
   add(method: string, path: string, handler: Function | Function[]) {

--- a/src/router/trie.ts
+++ b/src/router/trie.ts
@@ -1,8 +1,9 @@
 import { ALL_METHOD, EMPTY_OBJ } from "../constant";
+import { Find } from "./interface";
 
 class TrieNodes {
   children: Record<string, TrieNodes>;
-  handlers: Record<string, Function>;
+  handlers: Record<string, Array<Function>>;
   middlewares: Function[];
   params: Record<string, number>;
   paramName: string;
@@ -53,11 +54,13 @@ export class TrieRouter {
     return this.pushMiddleware(path, handlers);
   }
 
-  insert(method: string, path: string, handler: Function) {
+  insert(method: string, path: string, handler: Function | Function[]) {
+    const handlers = Array.isArray(handler) ? handler : [handler];
     let node = this.root;
 
     if (path === "/") {
-      node.handlers[method] = handler;
+      node.handlers[method] ??= [];
+      node.handlers[method].push(...handlers);
       node.params = EMPTY_OBJ;
       return;
     }
@@ -83,14 +86,15 @@ export class TrieRouter {
       }
     }
     node.params = routeparams;
-    node.handlers[method] = handler;
+    node.handlers[method] ??= [];
+    node.handlers[method].push(...handlers);
   }
 
-  add(method: string, path: string, handler: Function) {
+  add(method: string, path: string, handler: Function | Function[]) {
     return this.insert(method, path, handler);
   }
 
-  search(method: string, path: string) {
+  search(method: string, path: string): Find {
     let node = this.root;
 
     const pathSegments = path.split("/");

--- a/src/utils/request.util.ts
+++ b/src/utils/request.util.ts
@@ -114,9 +114,8 @@ export async function handleRouteNotFound(diesel: Diesel, ctx: ContextType, path
 
   const wildcard = diesel.router.find(ctx.req.method, '*');
   const arr: handlerFunction[] | any = wildcard?.handler
-  const handler = arr.slice(-1)
-  if (handler.length > 0) {
-    const res = await handler[0](ctx)
+  if (arr?.length > 0) {
+    const res = await arr[arr.length - 1](ctx)
     if (isResponse(res)) return res
   }
 

--- a/test/test-midl-in-method.test.ts
+++ b/test/test-midl-in-method.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test'
+import { app } from './server'
+import Diesel from '../src/main'
+import type { ContextType } from '../index'
+
+const port = 3001
+const baseUrl = `http://localhost:${port}`
+
+// Tracks which middlewares ran for the current request
+let ranMiddlewares: string[] = []
+
+const auth_check = (_ctx: ContextType) => {
+  ranMiddlewares.push('auth_check')
+}
+
+const auth_check_post = (_ctx: ContextType) => {
+  ranMiddlewares.push('auth_check_post')
+}
+
+const get_user = (ctx: ContextType) => {
+  return ctx.json({ role: 'user', method: 'GET' })
+}
+
+const create_user = (ctx: ContextType) => {
+  return ctx.json({ role: 'user', method: 'POST' })
+}
+
+beforeAll(async () => {
+  const user_router = new Diesel()
+  user_router.get('/', auth_check as any, get_user as any)
+  user_router.post('/', auth_check_post as any, create_user as any)
+
+  app.mount('/users', user_router)
+
+  app.listen(port, () => {
+    console.log('Server running on ' + port)
+  })
+})
+
+afterAll(async () => {
+  app.close()
+  console.log('Server closed.')
+})
+
+beforeEach(() => {
+  ranMiddlewares = []
+})
+
+describe('Middleware isolation — GET /users', () => {
+  it('should return 200', async () => {
+    const res = await fetch(`${baseUrl}/users`)
+    expect(res.status).toBe(200)
+  })
+
+  it('auth_check should run for GET', async () => {
+    await fetch(`${baseUrl}/users`)
+    expect(ranMiddlewares).toContain('auth_check')
+  })
+
+  // main test
+  it('auth_check_post should NOT run for GET', async () => {
+    await fetch(`${baseUrl}/users`)
+    expect(ranMiddlewares).not.toContain('auth_check_post')
+  })
+
+  it('auth_check should run exactly once for GET', async () => {
+    await fetch(`${baseUrl}/users`)
+    const count = ranMiddlewares.filter(m => m === 'auth_check').length
+    expect(count).toBe(1)
+  })
+})
+
+describe('Middleware isolation — POST /users', () => {
+  it('should return 200', async () => {
+    const res = await fetch(`${baseUrl}/users`, { method: 'POST' })
+    expect(res.status).toBe(200)
+  })
+
+  it('auth_check_post should run for POST', async () => {
+    await fetch(`${baseUrl}/users`, { method: 'POST' })
+    expect(ranMiddlewares).toContain('auth_check_post')
+  })
+
+  // main test
+  it('auth_check should NOT run for POST', async () => {
+    await fetch(`${baseUrl}/users`, { method: 'POST' })
+    expect(ranMiddlewares).not.toContain('auth_check')
+  })
+
+  it('auth_check_post should run exactly once for POST', async () => {
+    await fetch(`${baseUrl}/users`, { method: 'POST' })
+    const count = ranMiddlewares.filter(m => m === 'auth_check_post').length
+    expect(count).toBe(1)
+  })
+})


### PR DESCRIPTION
the problem 
- when user do `app.get("/path", fn1(), main_handler)` and  `app.post("/path", postfnc1(), main_handler())`
- ideally when req comes with GET method then only get method's middleware shoudl fire but our `add_route` method was storing chaing fnc as midl in route so all middl used to get fired even though method was diffrent.