### PR TITLE
fix: scope param name resolution by HTTP method in trie router

### DIFF
--- a/lib/router/trie.test.ts
+++ b/lib/router/trie.test.ts
@@ -260,3 +260,51 @@ describe("dynamic test again with dff", () => {
     expect(result.handler?.[0](result.params as any)).toBe("posts");
   });
 });
+
+describe("BUG: param name collision on shared trie nodes", () => {
+  // These document a real bug: TrieNodes stores a single mutable `paramName`
+  // field per node, but a node at a given tree position can be shared by
+  // routes that were registered with different param names (different
+  // methods, or different methods, or diverging branches on the same method).
+  // Whichever route was inserted LAST wins the name for ALL routes sharing
+  // that node. See comments in trie.ts (insert/search) for the mechanics.
+  //
+  // All three tests below currently FAIL against the buggy implementation.
+  // They should pass once paramName/params resolution is scoped per
+  // method + route instead of shared per node.
+
+  test("BUG: different param names for same path shape across different methods", () => {
+    const router = new TrieRouter();
+    router.add("GET", "/user/:id", () => "get");
+    router.add("DELETE", "/user/:user_id", () => "delete");
+
+    const getResult = router.find("GET", "/user/123");
+    const deleteResult = router.find("DELETE", "/user/123");
+
+    expect(getResult.params).toEqual({ id: "123" });
+    expect(deleteResult.params).toEqual({ user_id: "123" });
+  });
+
+  test("BUG: different param names for same method on diverging branches", () => {
+    const router = new TrieRouter();
+    router.add("GET", "/user/:id/profile", () => "profile");
+    router.add("GET", "/user/:name/settings", () => "settings");
+
+    const profileResult = router.find("GET", "/user/123/profile");
+    const settingsResult = router.find("GET", "/user/123/settings");
+
+    expect(profileResult.params).toEqual({ id: "123" });
+    expect(settingsResult.params).toEqual({ name: "123" });
+  });
+
+  test("BUG: three methods sharing identical path shape with distinct param names", () => {
+    const router = new TrieRouter();
+    router.add("GET", "/item/:itemId", () => "get");
+    router.add("PUT", "/item/:updateId", () => "put");
+    router.add("DELETE", "/item/:deleteId", () => "delete");
+
+    expect(router.find("GET", "/item/9").params).toEqual({ itemId: "9" });
+    expect(router.find("PUT", "/item/9").params).toEqual({ updateId: "9" });
+    expect(router.find("DELETE", "/item/9").params).toEqual({ deleteId: "9" });
+  });
+});

--- a/lib/router/trie.ts
+++ b/lib/router/trie.ts
@@ -6,13 +6,11 @@ class TrieNodes {
   handlers: Record<string, Array<Function>>;
   middlewares: Function[];
   params: Record<string, string>;
-  paramName: string;
   constructor() {
     this.children = {};
     this.handlers = {};
     this.middlewares = [];
     this.params = {};
-    this.paramName = "";
   }
 }
 
@@ -80,7 +78,6 @@ export class TrieRouter {
 
       if (cleanParam) {
         node.params[method] = cleanParam;
-        node.paramName = cleanParam;
       }
     }
     if (node.handlers[method]) return;

--- a/lib/router/trie.ts
+++ b/lib/router/trie.ts
@@ -5,7 +5,7 @@ class TrieNodes {
   children: Record<string, TrieNodes>;
   handlers: Record<string, Array<Function>>;
   middlewares: Function[];
-  params: Record<string, number>;
+  params: Record<string, string>;
   paramName: string;
   constructor() {
     this.children = {};
@@ -65,7 +65,6 @@ export class TrieRouter {
 
     const pathSegments = path.split("/").filter(Boolean);
 
-    let routeparams: Record<string, number> = {};
     for (let i = 0; i < pathSegments.length; i++) {
       const element = pathSegments[i];
       let key = element;
@@ -78,12 +77,12 @@ export class TrieRouter {
       if (!node.children[key]) node.children[key] = new TrieNodes();
 
       node = node.children[key];
+
       if (cleanParam) {
-        routeparams[cleanParam] = i;
+        node.params[method] = cleanParam;
         node.paramName = cleanParam;
       }
     }
-    node.params = routeparams;
     if (node.handlers[method]) return;
     node.handlers[method] = handlers;
   }
@@ -105,7 +104,6 @@ export class TrieRouter {
       if (element.length === 0) {
         continue;
       }
-
       const wildcardChild = node.children["*"];
       if (node.children[element]) {
         if (wildcardChild) {
@@ -120,7 +118,7 @@ export class TrieRouter {
         }
         node = node.children[":"];
         if (!paramObject) paramObject = {};
-        paramObject[node.paramName] = element;
+        paramObject[node.params[method]] = element;
       } else if (wildcardChild) {
         node = wildcardChild;
         break;
@@ -132,7 +130,6 @@ export class TrieRouter {
         };
       }
     }
-
     if (node.middlewares.length > 0) {
       const mw = node.middlewares;
       for (let j = 0; j < mw.length; j++) {
@@ -169,9 +166,21 @@ export class TrieRouter {
 }
 
 // const t1 = new TrieRouter()
-// // t1.insert('GET', '/user/:id', () => "Hello /")
+// t1.add("GET", "/user/:id/profile", () => "profile");
+// t1.add("GET", "/user/:name/settings", () => "settings");
+
+// const profileResult = t1.find("GET", "/user/123/profile");
+// const settingsResult = t1.find("DELETE", "/user/123/settings");
+
+// console.log("prifleResult ", profileResult)
+// console.log("settingsResult ", settingsResult)
+
+
+// t1.insert('GET', '/user/:id', () => "Hello /")
+// t1.insert('DELETE', '/user/:ids', () => "Hello /")
+
 // t1.insert('GET', "/ok/:id/username/:number", () => "Hello /")
-// const handler = t1.search('GET', '/ok/1/username/2')
+// const handler = t1.search('GET', '/user/2')
 // console.log('real worldf handler = ',handler)
 // t1.insert('GET', '/user/:id/:number/contact', () => "Hello /")
 // t1.insert('GET', "/:username", () => "Hell /user")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diesel-core",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Web framework built on Web Standards",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Cross-method param name collisions (e.g. GET /user/:id vs DELETE /user/:user_id sharing a trie node) now resolve to the correct name per method. Same-method diverging branches sharing a node still collide; tracked separately.

chore: bump version to 2.2.5