### PR TITLE
refactor: make JWT auth and logger caller-supplied to shrink core bundle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@types/uuid": "^10.0.0",
       },
       "peerDependencies": {
-        "typescript": "^5.0.0",
+        "typescript": "7",
       },
     },
   },

--- a/example/app.ts
+++ b/example/app.ts
@@ -74,8 +74,8 @@ app.use('/body', fileSaveMiddleware({ fields: ["avatar"] }));
 // app.use(securityMiddleware)
 
 app.use(requestId())
-app.useLogger({ app })
-// app.useAdvancedLogger({app})
+app.useLogger(logger)
+// app.useAdvancedLogger(advancedLogger)
 
 // app.use(requestId())
 

--- a/example/app2.ts
+++ b/example/app2.ts
@@ -1,5 +1,6 @@
 import Diesel from "../src/main";
 import jwt from 'jsonwebtoken'
+import { logger } from '../src/middlewares/logger/logger'
 import { BunRequest } from "bun";
 import { ContextType } from "../src/types";
 const app = new Diesel()
@@ -25,7 +26,7 @@ app.use(() => {
 })
 
 app.addHooks('onRequest', () => { console.log('onRequest') })
-app.useLogger({ app })
+app.useLogger(logger)
 // app.use(authJwt)
 
 // app.setupFilter()

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -22,17 +22,10 @@ import {
 
 import { Server } from "bun";
 
-import {
-  advancedLogger,
+import type {
   AdvancedLoggerOptions,
-  logger,
   LoggerOptions,
 } from "./middlewares/logger/logger.js";
-
-import {
-  authenticateJwtDbMiddleware,
-  authenticateJwtMiddleware,
-} from "./utils/jwt.js";
 
 import {
   build_request_pipeline_latest,
@@ -123,7 +116,6 @@ export default class Diesel {
       jwtSecret,
       idleTimeOut = 10,
       pipelineArchitecture = false,
-      logger,
       onError,
     } = options;
 
@@ -171,15 +163,6 @@ export default class Diesel {
       this.addHooks("onError", (err: ErrnoException, path: string) => {
         console.log("Got an exception:", err);
         console.log("Request Path:", path);
-      });
-
-    // if user wants to log
-    if (logger)
-      this.useLogger({
-        app: this,
-        // onError(err) {
-        //   console.error('Got an exception:', err?.message ?? err?.cause);
-        // },
       });
 
     this.filterFunction = null;
@@ -262,7 +245,16 @@ export default class Diesel {
         }
       },
 
-      authenticateJwt: (jwt: any) => {
+      // Pass the middleware builder (e.g. `authenticateJwtMiddleware` from
+      // "diesel-core/jwt") so core doesn't carry JWT verification code for
+      // apps that never use it.
+      authenticateJwt: (
+        buildJwtAuth: (
+          jwt: any,
+          secret: string,
+        ) => (ctx: Context) => Response | Promise<Response | void> | void,
+        jwt: any,
+      ) => {
         if (!this.user_jwt_secret)
           throw new Error(
             "You must provide jwtSecret in Diesel Options to use authenticateJwt",
@@ -273,16 +265,21 @@ export default class Diesel {
             if (pathname.startsWith(pub)) return;
           }
 
-          const res = authenticateJwtMiddleware(
-            jwt,
-            this.user_jwt_secret!,
-          )(ctx);
+          const res = buildJwtAuth(jwt, this.user_jwt_secret!)(ctx);
           if (res) return res;
         };
         this.router.addMiddleware("/", wrapper);
       },
 
-      authenticateJwtDB: (jwt: any, User: any) => {
+      authenticateJwtDB: (
+        buildJwtDbAuth: (
+          jwt: any,
+          User: any,
+          secret: string,
+        ) => (ctx: Context) => Response | Promise<Response | void> | void,
+        jwt: any,
+        User: any,
+      ) => {
         if (!this.user_jwt_secret)
           throw new Error(
             "You must provide jwtSecret in Diesel Options to use authenticateJwt",
@@ -293,11 +290,7 @@ export default class Diesel {
             if (pathname.startsWith(pub)) return;
           }
 
-          const res = authenticateJwtDbMiddleware(
-            jwt,
-            User,
-            this.user_jwt_secret!,
-          )(ctx);
+          const res = buildJwtDbAuth(jwt, User, this.user_jwt_secret!)(ctx);
           if (res) return res;
         };
         this.router.addMiddleware("/", wrapper);
@@ -382,14 +375,22 @@ export default class Diesel {
     return this;
   }
 
-  // For logging incoming requests
-  useLogger(options: LoggerOptions) {
-    logger(options);
+  // For logging incoming requests. Pass the `logger` implementation
+  // (e.g. `import { logger } from "diesel-core/logger"`) so it's only
+  // bundled for apps that actually use it.
+  useLogger(
+    loggerFn: (options: LoggerOptions) => void,
+    options?: Omit<LoggerOptions, "app">,
+  ) {
+    loggerFn({ ...options, app: this } as LoggerOptions);
     return this;
   }
 
-  useAdvancedLogger(options: AdvancedLoggerOptions) {
-    advancedLogger(options);
+  useAdvancedLogger(
+    loggerFn: (options: AdvancedLoggerOptions) => void,
+    options?: Omit<AdvancedLoggerOptions, "app">,
+  ) {
+    loggerFn({ ...options, app: this } as AdvancedLoggerOptions);
     return this;
   }
 

--- a/lib/middlewares/jwt/index.ts
+++ b/lib/middlewares/jwt/index.ts
@@ -2,6 +2,8 @@ import Diesel from "../../main";
 import { ContextType } from "../../types";
 import { authenticateJwtDbMiddleware, authenticateJwtMiddleware } from "../../utils/jwt";
 
+export { authenticateJwtMiddleware, authenticateJwtDbMiddleware };
+
 type authenticateJwtT = {
     app:Diesel,
     jwt:any,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -123,8 +123,15 @@ export interface FilterMethods {
     publicRoutes: (...routes: string[]) => FilterMethods;
     permitAll: () => FilterMethods;
     authenticate: (fnc?: middlewareFunc[]) => Response | Promise<Response | null> | void;
-    authenticateJwt: (jwt: any) => Response | Promise<Response | null> | void;
-    authenticateJwtDB: (jwt: any, UserModel: any) => Response | Promise<Response | null> | void
+    authenticateJwt: (
+        buildJwtAuth: (jwt: any, secret: string) => (ctx: any) => any,
+        jwt: any,
+    ) => Response | Promise<Response | null> | void;
+    authenticateJwtDB: (
+        buildJwtDbAuth: (jwt: any, UserModel: any, secret: string) => (ctx: any) => any,
+        jwt: any,
+        UserModel: any,
+    ) => Response | Promise<Response | null> | void
 }
 export type listenArgsT = string | (() => void) | { cert?: string; key?: string };
 
@@ -161,7 +168,6 @@ export interface DieselOptions {
     idleTimeOut?: number;
     prefixApiUrl?: string;
     onError?: boolean;
-    logger?: boolean;
     pipelineArchitecture?: boolean;
     errorFormat?: errorFormat
     platform?: string;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diesel-core",
   "version": "2.2.6",
-  "description": "Web framework built on Web Standards",
+  "description": "Fast, minimal library for building backend APIs on Web Standards",
   "main": "index.js",
   "types": "index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/uuid": "^10.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "7"
   },
   "dependencies": {
     "peepal-router": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diesel-core",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Web framework built on Web Standards",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diesel-core",
-  "version": "2.2.6",
+  "version": "2.3.0",
   "description": "Fast, minimal library for building backend APIs on Web Standards",
   "main": "index.js",
   "types": "index.d.ts",
@@ -107,7 +107,7 @@
     "@types/uuid": "^10.0.0"
   },
   "peerDependencies": {
-    "typescript": "7"
+    "typescript": "^5.0.0"
   },
   "dependencies": {
     "peepal-router": "^0.5.0",


### PR DESCRIPTION
Core no longer bundles jsonwebtoken/find-my-way; authenticateJwt, authenticateJwtDB, useLogger, and useAdvancedLogger now accept the implementation function from the caller instead. Adds tests for multi-param routes with middleware across sub/route mounting.