### PR TITLE
build: only build real entrypoints, externalize real deps

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,17 +1,32 @@
-import { Glob } from 'bun';
-import { rm } from 'fs/promises';
+import { rm, readFile } from 'fs/promises';
+import pkg from './package.json';
 
 console.log('🧹 Cleaning dist...');
 await rm('./dist', { recursive: true, force: true });
 
-// Auto-discover all TS source files, skip tests
-const glob = new Glob('**/*.ts');
-const entrypoints = [];
-for await (const file of glob.scan('./lib')) {
-  if (!file.includes('.test.') && !file.includes('.spec.')) {
-    entrypoints.push(`./lib/${file}`);
-  }
+// Real npm dependencies must stay imports, not get inlined - otherwise
+// consumers ship them twice (once bundled here, once installed for real).
+const external = Object.keys(pkg.dependencies ?? {});
+
+// Only build what's actually reachable from the public package surface
+// (the exports map + what index.js loads directly). Everything else in
+// lib/ is internal-only - it already gets inlined wherever it's really
+// needed (splitting is off), so building it again as its own top-level
+// file just ships dead weight.
+const publicDistPaths = new Set();
+for (const entry of Object.values(pkg.exports)) {
+  if (entry.import?.startsWith('./dist/')) publicDistPaths.add(entry.import);
+  if (entry.require?.startsWith('./dist/')) publicDistPaths.add(entry.require);
 }
+
+const indexSource = await readFile('./index.js', 'utf8');
+for (const match of indexSource.matchAll(/from\s+['"](\.\/dist\/[^'"]+)['"]/g)) {
+  publicDistPaths.add(match[1]);
+}
+
+const entrypoints = [...publicDistPaths]
+  .filter((p) => p.endsWith('.js'))
+  .map((p) => p.replace(/^\.\/dist\//, './lib/').replace(/\.js$/, '.ts'));
 
 console.log(`📦 Building ${entrypoints.length} entrypoints...`);
 
@@ -22,6 +37,7 @@ const result = await Bun.build({
   minify: true,
   splitting: false,   // no shared chunks — each file is self-contained
   target: 'node',
+  external,
 });
 
 if (!result.success) {


### PR DESCRIPTION
- Bun.build() had no external list, so it inlined npm dependencies (peepal-router, uuid) instead of importing them, duplicating peepal-router across main.js and interface.js while consumers also install it separately via package.json's dependencies.
- The entrypoint list globbed every .ts file in lib/, so internal-only modules (request_pipeline.ts, router/interface.ts, router/trie.ts, utils/*.ts, constant.ts, conninfo.ts) got built and shipped as their own standalone dist files despite never being reachable from the exports map or index.js - dead weight, since they're already inlined wherever they're actually needed.

npm pack: 34.0kB -> 23.0kB. Verified via full smoke test against the packed tarball with peepal-router/uuid installed as real deps: every exports-map entry loads and the server serves real requests.