### PR TITLE
feat: bun, deno, and cloudflare adaptors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/deno": "^2.7.0",
         "@types/ejs": "^3.1.5",
       },
       "peerDependencies": {
@@ -18,6 +19,8 @@
   },
   "packages": {
     "@types/bun": ["@types/bun@1.2.5", "", { "dependencies": { "bun-types": "1.2.5" } }, "sha512-w2OZTzrZTVtbnJew1pdFmgV99H0/L+Pvw+z1P67HaR18MHOzYnTYOi6qzErhK8HyT+DB782ADVPPE92Xu2/Opg=="],
+
+    "@types/deno": ["@types/deno@2.7.0", "", {}, "sha512-Y6fWcV8KpYeO3Lik/RiYnUxtr/LWqoeACciU0CA+dr1U/45tGgaX3HWQQAPCNN53raN4Rr4Fht4y6qsUH57fDA=="],
 
     "@types/ejs": ["@types/ejs@3.1.5", "", {}, "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg=="],
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
       "types": "./dist/adaptor/deno/index.d.ts",
       "import": "./dist/adaptor/deno/index.js",
       "require": "./dist/adaptor/deno/index.js"
+    },
+    "./cloudflare": {
+      "types": "./dist/adaptor/cloudflare/index.d.ts",
+      "import": "./dist/adaptor/cloudflare/index.js",
+      "require": "./dist/adaptor/cloudflare/index.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,16 @@
       "types": "./dist/adaptor/node/main.d.ts",
       "import": "./dist/adaptor/node/main.js",
       "require": "./dist/adaptor/node/main.js"
+    },
+    "./bun": {
+      "types": "./dist/adaptor/bun/index.d.ts",
+      "import": "./dist/adaptor/bun/index.js",
+      "require": "./dist/adaptor/bun/index.js"
+    },
+    "./deno": {
+      "types": "./dist/adaptor/deno/index.d.ts",
+      "import": "./dist/adaptor/deno/index.js",
+      "require": "./dist/adaptor/deno/index.js"
     }
   },
   "scripts": {
@@ -103,6 +113,7 @@
   ],
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/deno": "^2.7.0",
     "@types/ejs": "^3.1.5"
   },
   "peerDependencies": {

--- a/src/adaptor/bun/index.test.ts
+++ b/src/adaptor/bun/index.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { unlink } from "node:fs/promises";
+import Diesel from "../../main";
+import { Context } from "../../ctx";
+import type { ContextType } from "../../types";
+import { connInfo, file } from "./index";
+
+describe('bun adaptor: connInfo', () => {
+
+    it('should return null when the context has no server', () => {
+        const ctx = new Context(new Request('http://localhost/ip'), undefined, '/ip', undefined, undefined, undefined);
+        expect(connInfo(ctx)).toBeNull();
+    });
+
+    it('should return the address info resolved by server.requestIP', () => {
+        const fakeServer = { requestIP: () => ({ address: '203.0.113.5', port: 1234, family: 'IPv4' }) };
+        const ctx = new Context(new Request('http://localhost/ip'), fakeServer, '/ip', undefined, undefined, undefined);
+        expect(connInfo(ctx)).toEqual({ address: '203.0.113.5', port: 1234, family: 'IPv4' });
+    });
+
+    it('should return null when server.requestIP resolves nothing', () => {
+        const fakeServer = { requestIP: () => null };
+        const ctx = new Context(new Request('http://localhost/ip'), fakeServer, '/ip', undefined, undefined, undefined);
+        expect(connInfo(ctx)).toBeNull();
+    });
+
+    describe('against a real Bun.serve request', () => {
+        const app = new Diesel();
+        app.get('/ip', (c: ContextType) => c.text(JSON.stringify(connInfo(c))));
+
+        let server: ReturnType<typeof Bun.serve>;
+
+        beforeAll(() => {
+            server = Bun.serve({ port: 3010, fetch: app.fetch as any });
+        });
+        afterAll(() => {
+            server.stop(true);
+        });
+
+        it('should resolve the real client IP through the fetch handler', async () => {
+            const res = await fetch('http://localhost:3010/ip');
+            const body = JSON.parse(await res.text());
+            expect(res.status).toBe(200);
+            expect(['127.0.0.1', '::1']).toContain(body.address);
+        });
+    });
+});
+
+describe('bun adaptor: file', () => {
+    const fixturePath = `${import.meta.dir}/__fixtures__/sample.txt`;
+    const fixtureContent = "hello from bun file adaptor";
+
+    beforeAll(async () => {
+        await Bun.write(fixturePath, fixtureContent);
+    });
+    afterAll(async () => {
+        await unlink(fixturePath);
+    });
+
+    it('should serve the file with a sniffed Content-Type and 200 status', async () => {
+        const ctx = new Context(new Request('http://localhost/file'), undefined, '/file', undefined, undefined, undefined);
+        const res = file(ctx, fixturePath);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('Content-Type')).toContain('text/plain');
+        expect(await res.text()).toBe(fixtureContent);
+    });
+
+    it('should honor an explicit mimeType override', async () => {
+        const ctx = new Context(new Request('http://localhost/file'), undefined, '/file', undefined, undefined, undefined);
+        const res = file(ctx, fixturePath, 'application/octet-stream');
+
+        expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
+    });
+
+    it('should honor a custom status and merge customHeaders', async () => {
+        const ctx = new Context(new Request('http://localhost/file'), undefined, '/file', undefined, undefined, undefined);
+        const res = file(ctx, fixturePath, undefined, 201, { 'X-Custom': 'yes' });
+
+        expect(res.status).toBe(201);
+        expect(res.headers.get('X-Custom')).toBe('yes');
+    });
+
+    it('should not clobber a Content-Type already set on ctx.headers', () => {
+        const ctx = new Context(new Request('http://localhost/file'), undefined, '/file', undefined, undefined, undefined);
+        ctx.setHeader('Content-Type', 'application/x-custom');
+        const res = file(ctx, fixturePath);
+
+        expect(res.headers.get('Content-Type')).toBe('application/x-custom');
+    });
+
+    describe('against a real Bun.serve request', () => {
+        const app = new Diesel();
+        app.get('/file', (c: ContextType) => file(c, fixturePath));
+
+        let server: ReturnType<typeof Bun.serve>;
+
+        beforeAll(() => {
+            server = Bun.serve({ port: 3011, fetch: app.fetch as any });
+        });
+        afterAll(() => {
+            server.stop(true);
+        });
+
+        it('should return the full file body', async () => {
+            const res = await fetch('http://localhost:3011/file');
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe(fixtureContent);
+        });
+
+        it('should support Range requests out of the box', async () => {
+            const res = await fetch('http://localhost:3011/file', { headers: { Range: 'bytes=0-4' } });
+            expect(res.status).toBe(206);
+            expect(res.headers.get('content-range')).toBe(`bytes 0-4/${fixtureContent.length}`);
+            expect(await res.text()).toBe(fixtureContent.slice(0, 5));
+        });
+    });
+});

--- a/src/adaptor/bun/index.ts
+++ b/src/adaptor/bun/index.ts
@@ -1,0 +1,33 @@
+import { Context } from "../../ctx.js";
+
+export const connInfo = (c: Context) => {
+  return c.server?.requestIP?.(c.req) ?? null;
+}
+
+export const file = (
+  c: Context,
+  filePath: string,
+  mimeType?: string,
+  status: number = 200,
+  customHeaders?: Record<string, string>,
+): Response => {
+  const bunFile = Bun.file(filePath);
+  const contentType = mimeType ?? bunFile.type;
+
+  if (!c.headers) {
+    const headers: Record<string, string> = { "Content-Type": contentType };
+    if (customHeaders) {
+      for (const k in customHeaders) headers[k] = customHeaders[k];
+    }
+    return new Response(bunFile, { status, headers });
+  }
+
+  if (customHeaders) {
+    for (const k in customHeaders) c.headers.set(k, customHeaders[k]);
+  }
+  if (!c.headers.has("Content-Type")) {
+    c.headers.set("Content-Type", contentType);
+  }
+
+  return new Response(bunFile, { status, headers: c.headers });
+};

--- a/src/adaptor/cloudflare/index.test.ts
+++ b/src/adaptor/cloudflare/index.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { Context } from "../../ctx";
+import { connInfo } from "./index";
+
+describe('cloudflare adaptor: connInfo', () => {
+
+    it('should return the CF-Connecting-IP header value', () => {
+        const req = new Request('http://localhost/ip', { headers: { 'CF-Connecting-IP': '203.0.113.5' } });
+        const ctx = new Context(req, undefined, '/ip', undefined, undefined, undefined);
+        expect(connInfo(ctx)).toBe('203.0.113.5');
+    });
+
+    it('should return null when the header is absent', () => {
+        const req = new Request('http://localhost/ip');
+        const ctx = new Context(req, undefined, '/ip', undefined, undefined, undefined);
+        expect(connInfo(ctx)).toBeNull();
+    });
+});

--- a/src/adaptor/cloudflare/index.ts
+++ b/src/adaptor/cloudflare/index.ts
@@ -1,0 +1,5 @@
+import { Context } from "../../ctx.js";
+
+export const connInfo = (c: Context): string | null => {
+  return c.req.headers.get('CF-Connecting-IP');
+}

--- a/src/adaptor/deno/index.test.ts
+++ b/src/adaptor/deno/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { Context } from "../../ctx";
+import { connInfo } from "./index";
+
+describe('deno adaptor: connInfo', () => {
+
+    it('should return null when the context has no server', () => {
+        const ctx = new Context(new Request('http://localhost/ip'), undefined, '/ip', undefined, undefined, undefined);
+        expect(connInfo(ctx)).toBeNull();
+    });
+
+    it('should return the remoteAddr resolved from Deno.serve\'s handler info', () => {
+        // Shape verified against a real `Deno.serve` handler's second argument:
+        // { transport: "tcp", hostname: "127.0.0.1", port: 53855 }
+        const fakeServer = { remoteAddr: { transport: 'tcp', hostname: '127.0.0.1', port: 53855 } };
+        const ctx = new Context(new Request('http://localhost/ip'), fakeServer as any, '/ip', undefined, undefined, undefined);
+        expect(connInfo(ctx)).toEqual({ transport: 'tcp', hostname: '127.0.0.1', port: 53855 });
+    });
+
+    it('should return null when the server info has no remoteAddr', () => {
+        const fakeServer = {};
+        const ctx = new Context(new Request('http://localhost/ip'), fakeServer as any, '/ip', undefined, undefined, undefined);
+        expect(connInfo(ctx)).toBeNull();
+    });
+});

--- a/src/adaptor/deno/index.ts
+++ b/src/adaptor/deno/index.ts
@@ -1,0 +1,41 @@
+import { Context } from "../../ctx.js";
+import { getMimeType } from "../../utils/mimeType.js";
+
+interface DenoNetAddr {
+  transport: string;
+  hostname: string;
+  port: number;
+}
+
+export const connInfo = (c: Context) => {
+  const server = c.server as unknown as { remoteAddr?: DenoNetAddr } | undefined;
+  return server?.remoteAddr ?? null;
+}
+
+export const file = async (
+  c: Context,
+  filePath: string,
+  mimeType?: string,
+  status: number = 200,
+  customHeaders?: Record<string, string>,
+): Promise<Response> => {
+  const fsFile = await Deno.open(filePath, { read: true });
+  const contentType = mimeType ?? getMimeType(filePath);
+
+  if (!c.headers) {
+    const headers: Record<string, string> = { "Content-Type": contentType };
+    if (customHeaders) {
+      for (const k in customHeaders) headers[k] = customHeaders[k];
+    }
+    return new Response(fsFile.readable, { status, headers });
+  }
+
+  if (customHeaders) {
+    for (const k in customHeaders) c.headers.set(k, customHeaders[k]);
+  }
+  if (!c.headers.has("Content-Type")) {
+    c.headers.set("Content-Type", contentType);
+  }
+
+  return new Response(fsFile.readable, { status, headers: c.headers });
+};

--- a/src/utils/mimeType.test.ts
+++ b/src/utils/mimeType.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { getMimeType } from "./mimeType";
+
+describe('getMimeType', () => {
+    const cases: Array<[string, string]> = [
+        ['file.js', 'application/javascript'],
+        ['file.mjs', 'application/javascript'],
+        ['file.ts', 'application/typescript'],
+        ['file.css', 'text/css'],
+        ['file.html', 'text/html'],
+        ['file.htm', 'text/html'],
+        ['file.txt', 'text/plain'],
+        ['file.csv', 'text/csv'],
+        ['file.xml', 'application/xml'],
+        ['file.json', 'application/json'],
+        ['file.md', 'text/markdown'],
+        ['file.png', 'image/png'],
+        ['file.jpg', 'image/jpeg'],
+        ['file.jpeg', 'image/jpeg'],
+        ['file.svg', 'image/svg+xml'],
+        ['file.gif', 'image/gif'],
+        ['file.webp', 'image/webp'],
+        ['file.ico', 'image/x-icon'],
+        ['file.bmp', 'image/bmp'],
+        ['file.avif', 'image/avif'],
+        ['file.mp3', 'audio/mpeg'],
+        ['file.wav', 'audio/wav'],
+        ['file.ogg', 'audio/ogg'],
+        ['file.mp4', 'video/mp4'],
+        ['file.webm', 'video/webm'],
+        ['file.mov', 'video/quicktime'],
+        ['file.avi', 'video/x-msvideo'],
+        ['file.woff', 'font/woff'],
+        ['file.woff2', 'font/woff2'],
+        ['file.ttf', 'font/ttf'],
+        ['file.otf', 'font/otf'],
+        ['file.pdf', 'application/pdf'],
+        ['file.zip', 'application/zip'],
+        ['file.gz', 'application/gzip'],
+        ['file.tar', 'application/x-tar'],
+        ['file.wasm', 'application/wasm'],
+        ['file.unknownext', 'application/octet-stream'],
+        ['file', 'application/octet-stream'],
+    ];
+
+    for (const [path, expected] of cases) {
+        it(`should map "${path}" to "${expected}"`, () => {
+            expect(getMimeType(path)).toBe(expected);
+        });
+    }
+
+    it('should be case-insensitive on the extension', () => {
+        expect(getMimeType('file.PNG')).toBe('image/png');
+        expect(getMimeType('file.JPG')).toBe('image/jpeg');
+    });
+
+    it('should use the last extension for a multi-dot path', () => {
+        expect(getMimeType('archive.tar.gz')).toBe('application/gzip');
+    });
+});

--- a/src/utils/mimeType.ts
+++ b/src/utils/mimeType.ts
@@ -1,14 +1,29 @@
 export function getMimeType(filePath: string): string {
     const ext = filePath.split('.').pop()?.toLowerCase();
     switch (ext) {
+      // text / web
       case 'js':
+      case 'mjs':
         return 'application/javascript';
+      case 'ts':
+        return 'application/typescript';
       case 'css':
         return 'text/css';
       case 'html':
+      case 'htm':
         return 'text/html';
+      case 'txt':
+        return 'text/plain';
+      case 'csv':
+        return 'text/csv';
+      case 'xml':
+        return 'application/xml';
       case 'json':
         return 'application/json';
+      case 'md':
+        return 'text/markdown';
+
+      // images
       case 'png':
         return 'image/png';
       case 'jpg':
@@ -18,10 +33,53 @@ export function getMimeType(filePath: string): string {
         return 'image/svg+xml';
       case 'gif':
         return 'image/gif';
+      case 'webp':
+        return 'image/webp';
+      case 'ico':
+        return 'image/x-icon';
+      case 'bmp':
+        return 'image/bmp';
+      case 'avif':
+        return 'image/avif';
+
+      // audio / video
+      case 'mp3':
+        return 'audio/mpeg';
+      case 'wav':
+        return 'audio/wav';
+      case 'ogg':
+        return 'audio/ogg';
+      case 'mp4':
+        return 'video/mp4';
+      case 'webm':
+        return 'video/webm';
+      case 'mov':
+        return 'video/quicktime';
+      case 'avi':
+        return 'video/x-msvideo';
+
+      // fonts
       case 'woff':
         return 'font/woff';
       case 'woff2':
         return 'font/woff2';
+      case 'ttf':
+        return 'font/ttf';
+      case 'otf':
+        return 'font/otf';
+
+      // documents / archives
+      case 'pdf':
+        return 'application/pdf';
+      case 'zip':
+        return 'application/zip';
+      case 'gz':
+        return 'application/gzip';
+      case 'tar':
+        return 'application/x-tar';
+      case 'wasm':
+        return 'application/wasm';
+
       default:
         return 'application/octet-stream';
     }


### PR DESCRIPTION
Adds runtime adaptors under diesel-core/bun, diesel-core/deno, and diesel-core/cloudflare, each exporting a connInfo(ctx) for real client-IP resolution (via Bun.file/server.requestIP, Deno.serve's remoteAddr, and Cloudflare's edge-set CF-Connecting-IP respectively). Bun and Deno also get a file(ctx, path, ...) helper mirroring c.file()'s signature but built on each runtime's native file API (Bun.file, Deno.open) — Bun's version additionally gets automatic Range/partial-content support for free. Also expands the shared getMimeType util from 6 to ~35 recognized extensions. Wired into package.json's exports map so build.js actually bundles them, with tests for all three adaptors and the mimeType util.