### PR TITLE
fix: centralize HEAD body-stripping and preserve statusText

### DIFF
--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -155,7 +155,6 @@ export class Context {
     status: number = 200,
     customHeaders?: Record<string, string>,
   ): Response {
-    data = this.req.method === "HEAD" ? null as any : data;
     if (!this.headers) {
       if (!customHeaders) {
         return new Response(data, status === 200 ? _TEXT_INIT : _TEXT_INIT_WITH_STATUS(status));
@@ -196,7 +195,6 @@ export class Context {
       contentType = "text/plain; charset=utf-8";
       responseData = String(data);
     }
-    if (this.req.method === "HEAD") responseData = null;
     if (!this.headers) {
       if (!customHeaders) {
         return new Response(responseData, {
@@ -227,16 +225,9 @@ export class Context {
     status: number = 200,
     customHeaders?: Record<string, string>,
   ): Response {
-    const isHead = this.req.method === "HEAD";
 
     if (!this.headers) {
       if (!customHeaders) {
-        if (isHead) {
-          return new Response(null, {
-            status,
-            headers: { "Content-Type": "application/json; charset=utf-8" },
-          });
-        }
         // Response.json() sets Content-Type automatically; skip options entirely when status=200
         return status === 200
           ? Response.json(object)
@@ -247,9 +238,7 @@ export class Context {
         "Content-Type": "application/json; charset=utf-8",
       };
       copyHeadersToObject(customHeaders, h);
-      return isHead
-        ? new Response(null, { status, headers: h })
-        : Response.json(object, { status, headers: h });
+      return Response.json(object, { status, headers: h });
     }
 
     // slow path
@@ -259,7 +248,7 @@ export class Context {
       this.headers.set("Content-Type", "application/json; charset=utf-8");
     }
 
-    return new Response(isHead ? null : JSON.stringify(object), {
+    return new Response(JSON.stringify(object), {
       status,
       headers: this.headers,
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -330,7 +330,11 @@ export default class Diesel {
           async (error: any) => {
             return this.handleError(error, ctx);
           },
-        );
+        )
+        .then((res: Response) => {
+          if (req.method === "HEAD") return new Response(null, { status: res?.status, statusText: res?.statusText, headers: res?.headers });
+          return res;
+        })
       };
     }
 
@@ -387,7 +391,10 @@ export default class Diesel {
           async (error: any) => {
             return this.handleError(error, ctx);
           },
-        );
+        ).then((res: Response) => {
+          if (req.method === "HEAD") return new Response(null, { status: res?.status, statusText: res?.statusText, headers: res?.headers });
+          return res;
+        })
       };
     }
 
@@ -417,9 +424,14 @@ export default class Diesel {
       env,
       executionContext,
     );
-    return this.#execute_handlers(ctx, matchedRouteHandler).catch((err: any) =>
+    return this.#execute_handlers(ctx, matchedRouteHandler)
+      .catch((err: any) =>
       this.handleError(err, ctx),
-    );
+    )
+    .then(res => {
+      if (req.method === "HEAD") return new Response(null, { status: res?.status, statusText: res?.statusText, headers: res?.headers });
+      return res;
+    })
   }
 
   async #execute_handlers(

--- a/test/head-method.test.ts
+++ b/test/head-method.test.ts
@@ -144,25 +144,28 @@ describe("HEAD method - explicit registration & middleware", () => {
   });
 });
 
-describe("HEAD method - accepted behavior (raw Response bypasses body stripping, not treated as a bug)", () => {
-  // ctx.text()/json()/send()/file()/stream() null the body themselves, but
-  // anything that hands back a `Response` WITHOUT going through those helpers
-  // skips that logic entirely. For error/404 paths this is accepted: the
-  // response is identical for GET and HEAD (no data-leak risk, no GET/HEAD
-  // inconsistency), so we're not chasing RFC 9110 purity here. These tests
-  // just pin the current behavior so a future change to it is deliberate.
+describe("HEAD method - raw Response paths are stripped too (central guard)", () => {
+  // ctx.text()/json()/send()/file()/stream() null the body themselves as an
+  // early-exit optimization (skips real work like disk I/O for ctx.file()).
+  // Anything that hands back a `Response` WITHOUT going through those helpers
+  // (onError hooks, the default 404 fallback, custom middleware) used to skip
+  // HEAD stripping entirely. A central guard in stripHeadBody() (utils/request.util.ts),
+  // applied once to whatever Response #handleRequests/#buildFetchHandler/cfFetch()
+  // resolve to, now catches those cases too - regardless of how the body was built.
 
-  it("an onError hook returning a raw Response keeps its body on HEAD (accepted)", async () => {
+  it("an onError hook returning a raw Response is stripped on HEAD", async () => {
     // ./server's onError hook does `return new Response(JSON.stringify(...), {status:500})`
     const headRes: Response = await get(app, "/error", "HEAD");
     expect(headRes.status).toBe(500);
-    expect(await headRes.clone().text()).toBe('{"message":"Something went wrong!"}');
+    expect(headRes.body).toBeNull();
+    expect(await headRes.clone().text()).toBe("");
   });
 
-  it("the default 404 'route not found' response keeps its body on HEAD (accepted)", async () => {
+  it("the default 404 'route not found' response is stripped on HEAD", async () => {
     const headRes: Response = await get(app, "/does-not-exist", "HEAD");
     expect(headRes.status).toBe(404);
-    expect(await headRes.clone().text()).toBe('{"error":"404 Route not found for /does-not-exist"}');
+    expect(headRes.body).toBeNull();
+    expect(await headRes.clone().text()).toBe("");
   });
 });
 


### PR DESCRIPTION
Strip the response body for HEAD requests in one place (main.ts, after the handler/hooks/404-fallback resolve) instead of per ctx.* serializer, so raw Response paths (onError hooks, default 404) get covered too. Removed the now-redundant early-null checks in ctx.text()/json()/send() (ctx.file()/stream() keep theirs, since those avoid real I/O). Also fixes statusText being dropped when the HEAD response is rebuilt.