### PR TITLE
perf: use strict undefined checks for router handler lookups

### DIFF
--- a/benchmark/bench-undefined-check.ts
+++ b/benchmark/bench-undefined-check.ts
@@ -1,0 +1,117 @@
+const ITER = 20_000_000;
+const TRIALS = 9;
+
+type MatchedRoute = { handler?: (() => void) | undefined };
+
+function makeRoutes(hitRate: number): MatchedRoute[] {
+  const routes: MatchedRoute[] = [];
+  for (let i = 0; i < 1000; i++) {
+    routes.push(i / 1000 < hitRate ? { handler: () => {} } : {});
+  }
+  return routes;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+type Check = { name: string; run: (routes: MatchedRoute[]) => number };
+
+const checks: Check[] = [
+  {
+    name: "if (!matched.handler)",
+    run: (routes) => {
+      let count = 0;
+      for (let i = 0; i < ITER; i++) {
+        if (!routes[i % routes.length].handler) count++;
+      }
+      return count;
+    },
+  },
+  {
+    name: "if (matched.handler === undefined)",
+    run: (routes) => {
+      let count = 0;
+      for (let i = 0; i < ITER; i++) {
+        if (routes[i % routes.length].handler === undefined) count++;
+      }
+      return count;
+    },
+  },
+  {
+    name: "if (matched.handler)",
+    run: (routes) => {
+      let count = 0;
+      for (let i = 0; i < ITER; i++) {
+        if (routes[i % routes.length].handler) count++;
+      }
+      return count;
+    },
+  },
+  {
+    name: "if (matched.handler !== undefined)",
+    run: (routes) => {
+      let count = 0;
+      for (let i = 0; i < ITER; i++) {
+        if (routes[i % routes.length].handler !== undefined) count++;
+      }
+      return count;
+    },
+  },
+];
+
+function runScenario(label: string, routes: MatchedRoute[]) {
+  console.log(`\n--- ${label} ---`);
+
+  const samples: Record<string, number[]> = {};
+  const lastSink: Record<string, number> = {};
+  for (const c of checks) samples[c.name] = [];
+
+  // Interleave trials round-robin across checks so no single check
+  // is unfairly biased by CPU thermal ramp / GC pauses / OS scheduling.
+  for (let t = 0; t < TRIALS; t++) {
+    for (const c of checks) {
+      const start = performance.now();
+      const sink = c.run(routes);
+      const elapsed = performance.now() - start;
+      samples[c.name].push(elapsed);
+      lastSink[c.name] = sink;
+    }
+  }
+
+  // Fixed order, grouped as negative pair then positive pair, so it's
+  // clear all four checks ran and which ones are counterparts.
+  console.log("negation form (checking handler is MISSING):");
+  for (const name of ["if (!matched.handler)", "if (matched.handler === undefined)"]) {
+    console.log(
+      `  ${name}: ${median(samples[name]).toFixed(2)} ms (median of ${TRIALS}, sink=${lastSink[name]})`,
+    );
+  }
+  console.log("positive form (checking handler IS PRESENT):");
+  for (const name of ["if (matched.handler)", "if (matched.handler !== undefined)"]) {
+    console.log(
+      `  ${name}: ${median(samples[name]).toFixed(2)} ms (median of ${TRIALS}, sink=${lastSink[name]})`,
+    );
+  }
+}
+
+console.log("Warming up...");
+const warmupRoutes = makeRoutes(0.5);
+for (let i = 0; i < 200_000; i++) {
+  const m = warmupRoutes[i % warmupRoutes.length];
+  if (!m.handler) {}
+  if (m.handler === undefined) {}
+  if (m.handler) {}
+  if (m.handler !== undefined) {}
+}
+for (const c of checks) c.run(warmupRoutes);
+
+console.log("Starting benchmarks");
+
+runScenario("90% routes have a handler", makeRoutes(0.9));
+runScenario("50% routes have a handler", makeRoutes(0.5));
+runScenario("10% routes have a handler", makeRoutes(0.1));
+
+console.log("\nDone.");

--- a/src/main.ts
+++ b/src/main.ts
@@ -317,7 +317,7 @@ export default class Diesel {
           req.method as HttpMethod,
           path,
         );
-        if (!matchedRouteHandler.handler && req.method === "HEAD") matchedRouteHandler = this.router.find("GET", path);
+        if (matchedRouteHandler.handler === undefined && req.method === "HEAD") matchedRouteHandler = this.router.find("GET", path);
         const ctx = new Context(
           req,
           undefined,
@@ -374,7 +374,7 @@ export default class Diesel {
           req.method as HttpMethod,
           path,
         );
-        if (!matchedRouteHandler.handler && req.method === "HEAD") matchedRouteHandler = this.router.find("GET", path);
+        if (matchedRouteHandler.handler === undefined && req.method === "HEAD") matchedRouteHandler = this.router.find("GET", path);
         const ctx = new Context(
           req,
           server,
@@ -407,7 +407,7 @@ export default class Diesel {
       req.method as HttpMethod,
       path,
     );
-    if (!matchedRouteHandler.handler && req.method === "HEAD") matchedRouteHandler = this.router.find("GET", path);
+    if (matchedRouteHandler.handler === undefined && req.method === "HEAD") matchedRouteHandler = this.router.find("GET", path);
 
     const ctx = new Context(
       req,
@@ -445,7 +445,7 @@ export default class Diesel {
     }
 
     let finalResult;
-    if (matchedRouteHandler.handler) {
+    if (matchedRouteHandler.handler !== undefined) {
       const handlers = matchedRouteHandler.handler;
       for (let i = 0; i < handlers.length; i++) {
         const result = handlers[i](ctx);

--- a/src/request_pipeline.ts
+++ b/src/request_pipeline.ts
@@ -246,7 +246,7 @@ export const build_request_pipeline_latest = (diesel: Diesel): Function => {
 
   // Handle the handler
   const handler = `let finalResult;
-  if (matchedRouteHandler.handler) {
+  if (matchedRouteHandler.handler !== undefined) {
     const handlers = matchedRouteHandler.handler;
     for (let i = 0; i < handlers.length; i++) {
       const result = handlers[i](ctx);


### PR DESCRIPTION
## Summary
- `Router.find().handler` is typed `Array<Function> | undefined`
- Use `=== undefined` / `!== undefined` instead of truthy/falsy checks (`!x`, `if (x)`) — a single identity comparison is cheaper than checks that account for every JS falsy value
- Benchmarked in `benchmark/bench-undefined-check.ts`

## Test plan
- [x] `bun test` — 183 pass (4 pre-existing failures unrelated to this change)